### PR TITLE
Adjust screenshot naming

### DIFF
--- a/lib/Pherkin/Extension/Weasel.pm
+++ b/lib/Pherkin/Extension/Weasel.pm
@@ -198,7 +198,7 @@ has _weasel => (is => 'rw',
 
 =cut
 
-my $img_num = 0;
+my %img_num = ();
 
 sub _save_screenshot {
     my ($self, $event, $phase) = @_;
@@ -206,7 +206,8 @@ sub _save_screenshot {
     return if ! $self->screenshots_dir;
     return if ! $self->screenshot_event_on("$phase-$event");
 
-    my $img_name = "$event-$phase-" . ($img_num++) . '.png';
+    $img_num{$event}++ if $phase !~ /post/;
+    my $img_name = "$event-$phase-" . $img_num{$event} . '.png';
     open my $fh, ">", $self->screenshots_dir . '/' . $img_name;
     $self->_weasel->session->screenshot($fh);
     close $fh;


### PR DESCRIPTION
Make numbering by phase and event instead of sequentialy.
