### PR TITLE
Tidied up dist.ini throwing warnings.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,7 +11,6 @@ repository.url    = https://github.com/ehuelsmann/pherkin-extension-weasel.git
 repository.web    = https://github.com/ehuelsmann/pherkin-extension-weasel
 repository.type   = git
 
-[@Basic]
 [@Filter]
 -bundle = @Basic
 -remove = Readme


### PR DESCRIPTION
Hi @ehuelsmann 

Please review the PR. 
It tries to address the following warning during build:

      [DZ] beginning to build Pherkin-Extension-Weasel
      [DZ] attempt to add CHANGES multiple times; added by: filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Basic/GatherDir (Dist::Zilla::Plugin::GatherDir line 226); filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Filter/GatherDir (Dist::Zilla::Plugin::GatherDir line 226)
      [DZ] attempt to add dist.ini multiple times; added by: filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Basic/GatherDir (Dist::Zilla::Plugin::GatherDir line 226); filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Filter/GatherDir (Dist::Zilla::Plugin::GatherDir line 226)
      [DZ] attempt to add README.md multiple times; added by: filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Basic/GatherDir (Dist::Zilla::Plugin::GatherDir line 226); filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Filter/GatherDir (Dist::Zilla::Plugin::GatherDir line 226)
      [DZ] attempt to add t/00-load.t multiple times; added by: filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Basic/GatherDir (Dist::Zilla::Plugin::GatherDir line 226); filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Filter/GatherDir (Dist::Zilla::Plugin::GatherDir line 226)
      [DZ] attempt to add lib/Pherkin/Extension/Weasel.pm multiple times; added by: filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Basic/GatherDir (Dist::Zilla::Plugin::GatherDir line 226); filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Filter/GatherDir (Dist::Zilla::Plugin::GatherDir line 226)
      [DZ] attempt to add lib/Pherkin/Extension/weasel_steps/nav_steps.pl multiple times; added by: filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Basic/GatherDir (Dist::Zilla::Plugin::GatherDir line 226); filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Filter/GatherDir (Dist::Zilla::Plugin::GatherDir line 226)
      [DZ] attempt to add lib/Pherkin/Extension/weasel_steps/widget_steps.pl multiple times; added by: filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Basic/GatherDir (Dist::Zilla::Plugin::GatherDir line 226); filename set by GatherDir (Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by @Filter/GatherDir (Dist::Zilla::Plugin::GatherDir line 226)
      [DZ] attempt to add META.yml multiple times; added by: text from coderef added by @Basic/MetaYAML (Dist::Zilla::Plugin::MetaYAML line 70); text from coderef added by @Filter/MetaYAML (Dist::Zilla::Plugin::MetaYAML line 70)
      [DZ] attempt to add LICENSE multiple times; added by: content added by @Basic/License (Dist::Zilla::Plugin::License line 37); content added by @Filter/License (Dist::Zilla::Plugin::License line 37)
      [DZ] attempt to add Makefile.PL multiple times; added by: content added by @Basic/MakeMaker (Dist::Zilla::Plugin::MakeMaker line 144); content set by MakeMaker (Dist::Zilla::Plugin::MakeMaker line 329); content set by MakeMaker (Dist::Zilla::Plugin::MakeMaker line 329); content added by @Filter/MakeMaker (Dist::Zilla::Plugin::MakeMaker line 144)
      [DZ] attempt to add MANIFEST multiple times; added by: bytes from coderef added by @Basic/Manifest (Dist::Zilla::Plugin::Manifest line 55); bytes from coderef added by @Filter/Manifest (Dist::Zilla::Plugin::Manifest line 55) aborting; duplicate files would be produced at /usr/local/share/perl/5.18.2/Dist/Zilla/App/Command/build.pm line 107.

As per Dist::Zilla::PluginBundle::Filter:

     This plugin bundle actually wraps and modifies another plugin bundle. It includes all the configuration for the bundle named in the -bundle attribute, but removes all the entries whose package is given in the -remove attributes.

Therefore just removing the following line in the dist.ini:

       [@Basic]

gives me this:

     [DZ] beginning to build Pherkin-Extension-Weasel
     [DZ] writing Pherkin-Extension-Weasel in Pherkin-Extension-Weasel-0.03
     [DZ] building archive with Archive::Tar::Wrapper
     [DZ] writing archive to Pherkin-Extension-Weasel-0.03.tar.gz
     [DZ] built in Pherkin-Extension-Weasel-0.03


Many Thanks.
Best Regards,
Mohammad S Anwar
