### PR TITLE
Remove blank screen captures

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+** 0.08 / 2019-06-22
+   - Remove empty screen captures
+
 ** 0.07 / 2019-06-21
    - Change minimum Perl version to static declaration in dist.ini
    - Resolve undefined variable warnings with logging enabled
@@ -7,7 +10,6 @@
      - no screenshots without logging
      - prevent screenshots from various features overwriting each other
      - add styling in html log for screenshots
-
 ** 0.06 / 2019-02-22
    - Actually write the HTML log when steps/scenarios/features
      complete

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Pherkin::Extension::Weasel - Pherkin extension for web-testing
 
 # VERSION
 
-0.07
+0.08
 
 # SYNOPSIS
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name     = Pherkin-Extension-Weasel
-version  = 0.07
+version  = 0.08
 author   = Erik Huelsmann <ehuels@gmail.com>
 copyright_holder = Erik Huelsmann
 main_module = lib/Pherkin/Extension/Weasel.pm

--- a/lib/Pherkin/Extension/Weasel.pm
+++ b/lib/Pherkin/Extension/Weasel.pm
@@ -5,7 +5,7 @@ Pherkin::Extension::Weasel - Pherkin extension for web-testing
 
 =head1 VERSION
 
-0.07
+0.08
 
 =head1 SYNOPSIS
 
@@ -45,7 +45,7 @@ package Pherkin::Extension::Weasel;
 use strict;
 use warnings;
 
-our $VERSION = '0.07';
+our $VERSION = '0.08';
 
 
 use File::Share ':all';
@@ -357,6 +357,8 @@ sub _save_screenshot {
 
     return if ! $self->screenshots_dir;
     return if ! $self->screenshot_event_on("$phase-$event");
+    my $url = $self->_weasel->session->driver->_driver->get_current_url();
+    return if !$url or $url =~ 'about:blank';
 
     my $img_name = md5_hex($self->_log->{feature}->{filename}) . "-$event-$phase-" . ($img_num++) . '.png';
     if (open my $fh, ">", $self->screenshots_dir . '/' . $img_name) {
@@ -386,6 +388,7 @@ sub _save_screenshot {
 =head1 CONTRIBUTORS
 
 Erik Huelsmann
+Yves Lavoie
 
 =head1 MAINTAINERS
 


### PR DESCRIPTION
Blank screenshots are produced while the screen is being refreshed. This PR removes them to provide more readable logs.