### PR TITLE
Handle undefined params

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.15   2020-08-29
+       - Don't try to fetch undefined parameters so we can test for
+         proper handling of 'When I enter "" into "field"'
 
 0.14   2020-04-26
        - Add steps 'When I fill in:' and 'When I fill "<>" with "<>"'
@@ -65,5 +68,3 @@
 
 
 0.01   2016-06-23
-
-

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name     = Pherkin-Extension-Weasel
-version  = 0.13
+version  = 0.15
 author   = Erik Huelsmann <ehuels@gmail.com>
 copyright_holder = Erik Huelsmann
 main_module = lib/Pherkin/Extension/Weasel.pm

--- a/lib/Pherkin/Extension/weasel_steps/widget_steps.pl
+++ b/lib/Pherkin/Extension/weasel_steps/widget_steps.pl
@@ -99,7 +99,7 @@ When qr/I select "(.*)" from the drop down "(.*)"/, sub {
         ->select_option($value);
 };
 
-When qr/I enter (([^"].*)|"(.*)") into "(.*)"/, sub {
+When qr/I enter (([^"].*)|"(.*)") into "(.+)"/, sub {
     my $param = $2;
     my $value = $3;
     my $label = $4;
@@ -107,7 +107,8 @@ When qr/I enter (([^"].*)|"(.*)") into "(.*)"/, sub {
     my $element = S->{ext_wsl}->page->find(
         "*labeled", text => $label);
     ok($element, "found element with label '$label'");
-    $value ||= C->stash->{feature}->{$param};
+    $value ||= C->stash->{feature}->{$param} if $param;
+    return if !$value && !$param;
     $element->click;
     $element->clear;
     $element->send_keys($value);


### PR DESCRIPTION
Don't try to fetch undefined parameters so we can test for proper handling of 'When I enter "" into "field"'
