### PR TITLE
Allow logging to be timestamped

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.16   2021-03-25
+       - Allow logging to be timestamped
+
 0.15   2020-11-22
        - Fix uninitialized variable warning in input step "I enter X into Y"
        - Remove duplicated preamble in 'widget_steps.pl' step file

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Pherkin::Extension::Weasel - Pherkin extension for web-testing
 
 # VERSION
 
-0.13
+0.16
 
 # SYNOPSIS
 
@@ -22,6 +22,7 @@ Pherkin::Extension::Weasel - Pherkin extension for web-testing
               # write screenshots to img/
               screenshots_dir: img
               screenshot_events:
+              timestamps: 0
               # generate screenshots before every step
               pre_step: 1
               # and at the end of every scenario

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name     = Pherkin-Extension-Weasel
-version  = 0.15
+version  = 0.16
 author   = Erik Huelsmann <ehuels@gmail.com>
 copyright_holder = Erik Huelsmann
 main_module = lib/Pherkin/Extension/Weasel.pm

--- a/lib/Pherkin/Extension/Weasel.pm
+++ b/lib/Pherkin/Extension/Weasel.pm
@@ -5,7 +5,7 @@ Pherkin::Extension::Weasel - Pherkin extension for web-testing
 
 =head1 VERSION
 
-0.15
+0.16
 
 =head1 SYNOPSIS
 
@@ -77,6 +77,8 @@ has index_template => (is => 'ro', isa => 'Str',
 
 has logging_dir => (is => 'ro', isa => 'Maybe[Str]');
 
+has timestamps => (is => 'ro', isa => 'Bool', default => 0);
+
 has templates_dir => (is => 'ro', isa => 'Str',
                       default => sub {
                           my $dist = __PACKAGE__;
@@ -86,6 +88,9 @@ has templates_dir => (is => 'ro', isa => 'Str',
 
 our $tmp_disable_logging = 0;
 
+use Time::HiRes qw(time);
+use POSIX qw(strftime);
+
 sub _weasel_log_hook {
     my $self = shift;
     my ($event, $log_item, $something) = @_;
@@ -93,8 +98,14 @@ sub _weasel_log_hook {
 
     my $log = $self->_log;
     if ($log and not $tmp_disable_logging) {
+        my $date = '';
+        if ( $self->timestamps ) {
+            my $t = time;
+            $date = strftime "%H:%M:%S", localtime $t;
+            $date .= sprintf ".%06d ", ($t-int($t))*1000000; # without rounding
+        }
         push @{$log->{step}->{logs}}, {
-            text => $log_text
+            text => $date . $log_text
         };
     }
 }

--- a/lib/Pherkin/Extension/Weasel.pm
+++ b/lib/Pherkin/Extension/Weasel.pm
@@ -98,14 +98,15 @@ sub _weasel_log_hook {
 
     my $log = $self->_log;
     if ($log and not $tmp_disable_logging) {
-        my $date = '';
+        my $timestamp = '';
         if ( $self->timestamps ) {
             my $t = time;
-            $date = strftime "%H:%M:%S", localtime $t;
-            $date .= sprintf ".%06d ", ($t-int($t))*1000000; # without rounding
+            $timestamp = strftime "%H:%M:%S", localtime $t;
+            $timestamp .= sprintf ".%06d ", ($t-int($t))*1000000; # without rounding
         }
         push @{$log->{step}->{logs}}, {
-            text => $date . $log_text
+            timestamp => $timestamp,
+            text => $log_text
         };
     }
 }

--- a/share/pherkin-weasel-html-log-default.html
+++ b/share/pherkin-weasel-html-log-default.html
@@ -61,8 +61,7 @@
 [% ELSIF row.step -%]
         <tbody class="step [% IF row.step.failing ; 'failing' ; END %]">
           <tr class="step">
-            <td>[% row.step.text | html %]</td>
-            <td></td>
+            <td colspan="2"><h3>[% row.step.text | html %]</h3></td>
             <td class="[% row.step.result.remove('[<>]') # compensate '<missing>'
                        %]">[% row.step.result | html %]</td>
           </tr>

--- a/share/pherkin-weasel-html-log-default.html
+++ b/share/pherkin-weasel-html-log-default.html
@@ -68,7 +68,7 @@
           </tr>
 [% FOR log IN row.step.logs -%]
           <tr class="log">
-            <td></td>
+            <td>[% log.timestamp | html %]</td>
             <td>[% log.text | html %]</td>
             <td></td>
           </tr>


### PR DESCRIPTION
Allow each logged entry to be time stamped to ease identifying long steps.